### PR TITLE
makes needed imports more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,11 @@ To Use, simply Wrap the Widget you want to add Focused Menu to, with FocusedMenu
                 ),
               ),
 ```
-
+To use the `FocusedMenuItem` widget, ensure that you have the modals library imported also:
+```dart
+import 'package:focused_menu/focused_menu.dart';
+import 'package:focused_menu/modals.dart';
+```
 ## Roadmap
 Plans to add more customizations.
 


### PR DESCRIPTION
Thanks for the library, it took me a solid five minutes to realize the `FocusedMenuItem` was in a seperate library haha. Showing the needed import declaration might help others like me who get tripped up.