### PR TITLE
add controller with open/close methods

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -23,7 +23,14 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class MyHomePage extends StatelessWidget {
+class MyHomePage extends StatefulWidget {
+  @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  FocusedMenuHolderController _avatarController = FocusedMenuHolderController();
+
   @override
   Widget build(BuildContext context) {
     return SafeArea(
@@ -43,81 +50,118 @@ class MyHomePage extends StatelessWidget {
                   ),
                   Expanded(child: Center()),
                   IconButton(icon: Icon(Icons.shopping_cart), onPressed: () {}),
-                  CircleAvatar(
-                    child: Image.asset("assets/images/dp_default.png"),
+                  FocusedMenuHolder(
+                    controller: _avatarController,
+                    onPressed: () {},
+                    menuItems: <FocusedMenuItem>[
+                      FocusedMenuItem(
+                        title: Text("This is a button"),
+                        trailingIcon: Icon(Icons.open_in_new),
+                        onPressed: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => ScreenTwo(),
+                            ),
+                          );
+                        },
+                      ),
+                    ],
+                    child: CircleAvatar(
+                      child: Image.asset("assets/images/dp_default.png"),
+                    ),
                   )
                 ],
               ),
               SizedBox(
                 height: 10,
               ),
+              ElevatedButton(
+                onPressed: () => _avatarController.open(),
+                child: Text('Open avatar menu'),
+              ),
               TextField(
-                decoration: InputDecoration(border: InputBorder.none, hintText: "Look for your Interest!", fillColor: Colors.grey.shade200, filled: true),
+                decoration: InputDecoration(
+                  border: InputBorder.none,
+                  hintText: "Look for your Interest!",
+                  fillColor: Colors.grey.shade200,
+                  filled: true,
+                ),
               ),
-              SizedBox(
-                height: 10,
-              ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: <Widget>[
-                  DropdownButton(
-                      style: TextStyle(fontSize: 15, color: Colors.black),
-                      icon: Icon(Icons.keyboard_arrow_down),
-                      underline: Container(
-                        color: Colors.white,
-                      ),
-                      items: ["Featured", "Most Rated", "Recent", "Popular"].map<DropdownMenuItem>((e) => DropdownMenuItem(child: Text(e))).toList(),
-                      onChanged: (newItem) {}),
-                  IconButton(icon: Icon(Icons.sort), onPressed: () {})
-                ],
-              ),
+              SizedBox(height: 10),
               SizedBox(
                 height: 10,
               ),
               Expanded(
                 child: GridView(
                   physics: BouncingScrollPhysics(),
-                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 2),
+                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: 2),
                   children: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
                       .map((e) => FocusedMenuHolder(
-                        menuWidth: MediaQuery.of(context).size.width*0.50,
-                        blurSize: 5.0,
-                        menuItemExtent: 45,
-                        menuBoxDecoration: BoxDecoration(color: Colors.grey,borderRadius: BorderRadius.all(Radius.circular(15.0))),
-                        duration: Duration(milliseconds: 100),
-                        animateMenuItems: true,
-                        blurBackgroundColor: Colors.black54,
-                        bottomOffsetHeight: 100,
-                        openWithTap: true,
-                        menuItems: <FocusedMenuItem>[
-                          FocusedMenuItem(title: Text("Open"),trailingIcon: Icon(Icons.open_in_new) ,onPressed: (){
-                            Navigator.push(context, MaterialPageRoute(builder: (context)=>ScreenTwo()));
-                          }),
-                          FocusedMenuItem(title: Text("Share"),trailingIcon: Icon(Icons.share) ,onPressed: (){}),
-                          FocusedMenuItem(title: Text("Favorite"),trailingIcon: Icon(Icons.favorite_border) ,onPressed: (){}),
-                          FocusedMenuItem(title: Text("Delete",style: TextStyle(color: Colors.redAccent),),trailingIcon: Icon(Icons.delete,color: Colors.redAccent,) ,onPressed: (){}),
-                        ],
-                        onPressed: (){},
-                        child: Card(
+                            menuWidth: MediaQuery.of(context).size.width * 0.50,
+                            blurSize: 5.0,
+                            menuItemExtent: 45,
+                            menuBoxDecoration: BoxDecoration(
+                                color: Colors.grey,
+                                borderRadius:
+                                    BorderRadius.all(Radius.circular(15.0))),
+                            duration: Duration(milliseconds: 100),
+                            animateMenuItems: true,
+                            blurBackgroundColor: Colors.black54,
+                            bottomOffsetHeight: 100,
+                            openWithTap: true,
+                            menuItems: <FocusedMenuItem>[
+                              FocusedMenuItem(
+                                  title: Text("Open"),
+                                  trailingIcon: Icon(Icons.open_in_new),
+                                  onPressed: () {
+                                    Navigator.push(
+                                        context,
+                                        MaterialPageRoute(
+                                            builder: (context) => ScreenTwo()));
+                                  }),
+                              FocusedMenuItem(
+                                  title: Text("Share"),
+                                  trailingIcon: Icon(Icons.share),
+                                  onPressed: () {}),
+                              FocusedMenuItem(
+                                  title: Text("Favorite"),
+                                  trailingIcon: Icon(Icons.favorite_border),
+                                  onPressed: () {}),
+                              FocusedMenuItem(
+                                  title: Text(
+                                    "Delete",
+                                    style: TextStyle(color: Colors.redAccent),
+                                  ),
+                                  trailingIcon: Icon(
+                                    Icons.delete,
+                                    color: Colors.redAccent,
+                                  ),
+                                  onPressed: () {}),
+                            ],
+                            onPressed: () {},
+                            child: Card(
                               child: Column(
                                 children: <Widget>[
                                   Image.asset("assets/images/image_$e.jpg"),
                                 ],
                               ),
                             ),
-                      ))
+                          ))
                       .toList(),
                 ),
               ),
             ],
           ),
         )),
-        bottomNavigationBar: BottomNavigationBar(items: <BottomNavigationBarItem>[
-          BottomNavigationBarItem(icon: Icon(Icons.add),label: "Home"),
-          BottomNavigationBarItem(icon: Icon(Icons.add),label: "Menu 2"),
-          BottomNavigationBarItem(icon: Icon(Icons.add),label: "Menu 3"),
-          BottomNavigationBarItem(icon: Icon(Icons.add),label: "Menu 4"),
-          BottomNavigationBarItem(icon: Icon(Icons.add),label: "Menu 5"),
+        bottomNavigationBar:
+            BottomNavigationBar(items: <BottomNavigationBarItem>[
+          BottomNavigationBarItem(icon: Icon(Icons.add), label: "Home"),
+          BottomNavigationBarItem(icon: Icon(Icons.add), label: "Menu 2"),
+          BottomNavigationBarItem(icon: Icon(Icons.add), label: "Menu 3"),
+          BottomNavigationBarItem(icon: Icon(Icons.add), label: "Menu 4"),
+          BottomNavigationBarItem(icon: Icon(Icons.add), label: "Menu 5"),
         ]),
       ),
     );

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -80,14 +80,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.2"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -106,7 +113,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -141,7 +148,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:
@@ -155,6 +162,6 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"

--- a/lib/focused_menu.dart
+++ b/lib/focused_menu.dart
@@ -32,7 +32,7 @@ class FocusedMenuHolder extends StatefulWidget {
   final List<FocusedMenuItem> menuItems;
   final bool? animateMenuItems;
   final BoxDecoration? menuBoxDecoration;
-  final Function onPressed;
+  final Function? onPressed;
   final Duration? duration;
   final double? blurSize;
   final Color? blurBackgroundColor;
@@ -48,6 +48,7 @@ class FocusedMenuHolder extends StatefulWidget {
       required this.child,
       required this.onPressed,
       required this.menuItems,
+      this.onPressed,
       this.duration,
       this.menuBoxDecoration,
       this.menuItemExtent,
@@ -93,7 +94,7 @@ class _FocusedMenuHolderState extends State<FocusedMenuHolder> {
     return GestureDetector(
         key: containerKey,
         onTap: () async {
-          widget.onPressed();
+          widget.onPressed?.call();
           if (widget.openWithTap) {
             await openMenu(context);
           }

--- a/lib/focused_menu.dart
+++ b/lib/focused_menu.dart
@@ -1,26 +1,27 @@
 library focused_menu;
 
 import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:focused_menu/modals.dart';
 
 class FocusedMenuHolderController {
   late _FocusedMenuHolderState _widgetState;
-  bool isOpened = false;
+  bool _isOpened = false;
 
   void _addState(_FocusedMenuHolderState widgetState) {
     this._widgetState = widgetState;
   }
 
-  open() {
+  void open() {
     _widgetState.openMenu(_widgetState.context);
-    isOpened = true;
+    _isOpened = true;
   }
 
-  close() {
-    if (isOpened) {
+  void close() {
+    if (_isOpened) {
       Navigator.pop(_widgetState.context);
-      isOpened = false;
+      _isOpened = false;
     }
   }
 }
@@ -46,7 +47,6 @@ class FocusedMenuHolder extends StatefulWidget {
   const FocusedMenuHolder(
       {Key? key,
       required this.child,
-      required this.onPressed,
       required this.menuItems,
       this.onPressed,
       this.duration,
@@ -67,7 +67,6 @@ class FocusedMenuHolder extends StatefulWidget {
 }
 
 class _FocusedMenuHolderState extends State<FocusedMenuHolder> {
-  FocusedMenuHolderController? _controller;
   GlobalKey containerKey = GlobalKey();
   Offset childOffset = Offset(0, 0);
   Size? childSize;

--- a/lib/focused_menu.dart
+++ b/lib/focused_menu.dart
@@ -4,6 +4,27 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:focused_menu/modals.dart';
 
+class FocusedMenuHolderController {
+  late _FocusedMenuHolderState _widgetState;
+  bool isOpened = false;
+
+  void _addState(_FocusedMenuHolderState widgetState) {
+    this._widgetState = widgetState;
+  }
+
+  open() {
+    _widgetState.openMenu(_widgetState.context);
+    isOpened = true;
+  }
+
+  close() {
+    if (isOpened) {
+      Navigator.pop(_widgetState.context);
+      isOpened = false;
+    }
+  }
+}
+
 class FocusedMenuHolder extends StatefulWidget {
   final Widget child;
   final double? menuItemExtent;
@@ -17,8 +38,10 @@ class FocusedMenuHolder extends StatefulWidget {
   final Color? blurBackgroundColor;
   final double? bottomOffsetHeight;
   final double? menuOffset;
+
   /// Open with tap insted of long press.
   final bool openWithTap;
+  final FocusedMenuHolderController? controller;
 
   const FocusedMenuHolder(
       {Key? key,
@@ -34,20 +57,29 @@ class FocusedMenuHolder extends StatefulWidget {
       this.menuWidth,
       this.bottomOffsetHeight,
       this.menuOffset,
-      this.openWithTap = false})
+      this.openWithTap = false,
+      this.controller})
       : super(key: key);
 
   @override
-  _FocusedMenuHolderState createState() => _FocusedMenuHolderState();
+  _FocusedMenuHolderState createState() => _FocusedMenuHolderState(controller);
 }
 
 class _FocusedMenuHolderState extends State<FocusedMenuHolder> {
+  FocusedMenuHolderController? _controller;
   GlobalKey containerKey = GlobalKey();
   Offset childOffset = Offset(0, 0);
   Size? childSize;
 
-  getOffset(){
-    RenderBox renderBox = containerKey.currentContext!.findRenderObject() as RenderBox;
+  _FocusedMenuHolderState(FocusedMenuHolderController? _controller) {
+    if (_controller != null) {
+      _controller._addState(this);
+    }
+  }
+
+  getOffset() {
+    RenderBox renderBox =
+        containerKey.currentContext!.findRenderObject() as RenderBox;
     Size size = renderBox.size;
     Offset offset = renderBox.localToGlobal(Offset.zero);
     setState(() {
@@ -119,7 +151,19 @@ class FocusedMenuDetails extends StatelessWidget {
   final double? menuOffset;
 
   const FocusedMenuDetails(
-      {Key? key, required this.menuItems, required this.child, required this.childOffset, required this.childSize,required this.menuBoxDecoration, required this.itemExtent,required this.animateMenu,required this.blurSize,required this.blurBackgroundColor,required this.menuWidth, this.bottomOffsetHeight, this.menuOffset})
+      {Key? key,
+      required this.menuItems,
+      required this.child,
+      required this.childOffset,
+      required this.childSize,
+      required this.menuBoxDecoration,
+      required this.itemExtent,
+      required this.animateMenu,
+      required this.blurSize,
+      required this.blurBackgroundColor,
+      required this.menuWidth,
+      this.bottomOffsetHeight,
+      this.menuOffset})
       : super(key: key);
 
   @override
@@ -129,10 +173,15 @@ class FocusedMenuDetails extends StatelessWidget {
     final maxMenuHeight = size.height * 0.45;
     final listHeight = menuItems.length * (itemExtent ?? 50.0);
 
-    final maxMenuWidth = menuWidth??(size.width * 0.70);
+    final maxMenuWidth = menuWidth ?? (size.width * 0.70);
     final menuHeight = listHeight < maxMenuHeight ? listHeight : maxMenuHeight;
-    final leftOffset = (childOffset.dx+maxMenuWidth ) < size.width ? childOffset.dx: (childOffset.dx-maxMenuWidth+childSize!.width);
-    final topOffset = (childOffset.dy + menuHeight + childSize!.height) < size.height - bottomOffsetHeight! ? childOffset.dy + childSize!.height + menuOffset! : childOffset.dy - menuHeight - menuOffset!;
+    final leftOffset = (childOffset.dx + maxMenuWidth) < size.width
+        ? childOffset.dx
+        : (childOffset.dx - maxMenuWidth + childSize!.width);
+    final topOffset = (childOffset.dy + menuHeight + childSize!.height) <
+            size.height - bottomOffsetHeight!
+        ? childOffset.dy + childSize!.height + menuOffset!
+        : childOffset.dy - menuHeight - menuOffset!;
     return Scaffold(
       backgroundColor: Colors.transparent,
       body: Container(
@@ -144,9 +193,11 @@ class FocusedMenuDetails extends StatelessWidget {
                   Navigator.pop(context);
                 },
                 child: BackdropFilter(
-                  filter: ImageFilter.blur(sigmaX: blurSize??4, sigmaY: blurSize??4),
+                  filter: ImageFilter.blur(
+                      sigmaX: blurSize ?? 4, sigmaY: blurSize ?? 4),
                   child: Container(
-                    color: (blurBackgroundColor??Colors.black).withOpacity(0.7),
+                    color:
+                        (blurBackgroundColor ?? Colors.black).withOpacity(0.7),
                   ),
                 )),
             Positioned(
@@ -168,8 +219,14 @@ class FocusedMenuDetails extends StatelessWidget {
                   decoration: menuBoxDecoration ??
                       BoxDecoration(
                           color: Colors.grey.shade200,
-                          borderRadius: const BorderRadius.all(Radius.circular(5.0)),
-                          boxShadow: [const BoxShadow(color: Colors.black38, blurRadius: 10, spreadRadius: 1)]),
+                          borderRadius:
+                              const BorderRadius.all(Radius.circular(5.0)),
+                          boxShadow: [
+                            const BoxShadow(
+                                color: Colors.black38,
+                                blurRadius: 10,
+                                spreadRadius: 1)
+                          ]),
                   child: ClipRRect(
                     borderRadius: const BorderRadius.all(Radius.circular(5.0)),
                     child: ListView.builder(
@@ -179,11 +236,9 @@ class FocusedMenuDetails extends StatelessWidget {
                       itemBuilder: (context, index) {
                         FocusedMenuItem item = menuItems[index];
                         Widget listItem = GestureDetector(
-                            onTap:
-                                () {
+                            onTap: () {
                               Navigator.pop(context);
                               item.onPressed();
-
                             },
                             child: Container(
                                 alignment: Alignment.center,
@@ -191,12 +246,16 @@ class FocusedMenuDetails extends StatelessWidget {
                                 color: item.backgroundColor ?? Colors.white,
                                 height: itemExtent ?? 50.0,
                                 child: Padding(
-                                  padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 14),
+                                  padding: const EdgeInsets.symmetric(
+                                      vertical: 8.0, horizontal: 14),
                                   child: Row(
-                                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                    mainAxisAlignment:
+                                        MainAxisAlignment.spaceBetween,
                                     children: <Widget>[
                                       item.title,
-                                      if (item.trailingIcon != null) ...[item.trailingIcon!]
+                                      if (item.trailingIcon != null) ...[
+                                        item.trailingIcon!
+                                      ]
                                     ],
                                   ),
                                 )));
@@ -221,10 +280,15 @@ class FocusedMenuDetails extends StatelessWidget {
                 ),
               ),
             ),
-            Positioned(top: childOffset.dy, left: childOffset.dx, child: AbsorbPointer(absorbing: true, child: Container(
-                width: childSize!.width,
-                height: childSize!.height,
-                child: child))),
+            Positioned(
+                top: childOffset.dy,
+                left: childOffset.dx,
+                child: AbsorbPointer(
+                    absorbing: true,
+                    child: Container(
+                        width: childSize!.width,
+                        height: childSize!.height,
+                        child: child))),
           ],
         ),
       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -66,14 +66,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.2"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -92,7 +99,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -127,7 +134,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:
@@ -141,6 +148,6 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.2
 homepage: https://github.com/retroportalstudio/focused_menu.git
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Adding a controller to programmatically open / close the contextual menu.

Example:

```dart
class ExampleWidget extends StatelessWidget {
  final FocusedMenuHolderController _focusedController =
      FocusedMenuHolderController();

  ExampleWidget({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return Row(
      children: [
        FocusedMenuHolder(
          controller: _focusedController,
          menuItems: [],
          onPressed: () {},
          child: FlutterLogo(),
          // ...
        ),
        Column(
          children: [
            IconButton(
              onPressed: () {
                _focusedController.open();
              },
              icon: Icon(Icons.open_in_new),
            ),
            IconButton(
              onPressed: () {
                _focusedController.close();
              },
              icon: Icon(Icons.close),
            )
          ],
        ),
      ],
    );
  }
```