### PR TITLE
Adding new option `rootNavigator`

### DIFF
--- a/lib/src/widgets/focus_menu_holder.dart
+++ b/lib/src/widgets/focus_menu_holder.dart
@@ -37,6 +37,10 @@ class FocusedMenuHolder extends StatefulWidget {
   final double? bottomOffsetHeight;
   final double? menuOffset;
 
+  /// If true, the menu will be opened in the root navigator. Use it only if you are using multiple navigators.
+  /// Default is false.
+  final bool rootNavitator;
+
   /// Open with tap insted of long press.
   final bool openWithTap;
   final FocusedMenuHolderController? controller;
@@ -57,6 +61,7 @@ class FocusedMenuHolder extends StatefulWidget {
     this.menuWidth,
     this.bottomOffsetHeight,
     this.menuOffset,
+    this.rootNavitator = false,
     this.openWithTap = false,
     this.controller,
     this.onOpened,
@@ -111,33 +116,34 @@ class _FocusedMenuHolderState extends State<FocusedMenuHolder> {
     _getOffset();
     widget.onOpened?.call();
 
-    await Navigator.push(
-      context,
-      PageRouteBuilder(
-        transitionDuration: widget.duration ?? Duration(milliseconds: 100),
-        pageBuilder: (context, animation, secondaryAnimation) {
-          animation = Tween(begin: 0.0, end: 1.0).animate(animation);
-          return FadeTransition(
-            opacity: animation,
-            child: FocusedMenuDetails(
-              itemExtent: widget.menuItemExtent,
-              menuBoxDecoration: widget.menuBoxDecoration,
-              child: widget.child,
-              childOffset: childOffset,
-              childSize: childSize,
-              menuItems: widget.menuItems,
-              blurSize: widget.blurSize,
-              menuWidth: widget.menuWidth,
-              blurBackgroundColor: widget.blurBackgroundColor,
-              animateMenu: widget.animateMenuItems ?? true,
-              bottomOffsetHeight: widget.bottomOffsetHeight ?? 0,
-              menuOffset: widget.menuOffset ?? 0,
-            ),
-          );
-        },
-        fullscreenDialog: true,
-        opaque: false,
-      ),
-    ).whenComplete(() => widget.onClosed?.call());
+    await Navigator.of(context, rootNavigator: widget.rootNavitator)
+        .push(
+          PageRouteBuilder(
+            transitionDuration: widget.duration ?? Duration(milliseconds: 100),
+            pageBuilder: (context, animation, secondaryAnimation) {
+              animation = Tween(begin: 0.0, end: 1.0).animate(animation);
+              return FadeTransition(
+                opacity: animation,
+                child: FocusedMenuDetails(
+                  itemExtent: widget.menuItemExtent,
+                  menuBoxDecoration: widget.menuBoxDecoration,
+                  child: widget.child,
+                  childOffset: childOffset,
+                  childSize: childSize,
+                  menuItems: widget.menuItems,
+                  blurSize: widget.blurSize,
+                  menuWidth: widget.menuWidth,
+                  blurBackgroundColor: widget.blurBackgroundColor,
+                  animateMenu: widget.animateMenuItems ?? true,
+                  bottomOffsetHeight: widget.bottomOffsetHeight ?? 0,
+                  menuOffset: widget.menuOffset ?? 0,
+                ),
+              );
+            },
+            fullscreenDialog: true,
+            opaque: false,
+          ),
+        )
+        .whenComplete(() => widget.onClosed?.call());
   }
 }


### PR DESCRIPTION
Adding new option `rootNavigator`.

This option is useful when you are using multiple navigators, especially with a bottom navigation bar.
By default, when the menu is open, the bottom navigation bar is still visible/accessible, which sometimes it is not expected.

Setting `rootNavigator: true` allow to open the menu in the root navigator and makes the bottom bar behind the holder/overlay.

Before:

https://github.com/retroportalstudio/focused_menu/assets/3192298/ee4ab941-0188-4be9-a9c4-772966197c8b

After (rootNavigator: true):

https://github.com/retroportalstudio/focused_menu/assets/3192298/6b3c99f0-ac63-4f39-b30b-a87e4953c09e

