### PR TITLE
Extract more settings from FocusedMenuHolder

### DIFF
--- a/example/lib/example1.dart
+++ b/example/lib/example1.dart
@@ -55,6 +55,8 @@ class _Example1State extends State<Example1> {
                               color: Colors.grey,
                               borderRadius:
                                   BorderRadius.all(Radius.circular(15.0))),
+                          itemsCardBorderRadius:
+                              BorderRadius.all(Radius.circular(5)),
                           duration: Duration(milliseconds: 100),
                           animateMenuItems: true,
                           blurBackgroundColor: Colors.black54,

--- a/lib/src/widgets/focus_menu_holder.dart
+++ b/lib/src/widgets/focus_menu_holder.dart
@@ -25,17 +25,37 @@ class FocusedMenuHolderController {
 
 class FocusedMenuHolder extends StatefulWidget {
   final Widget child;
-  final double? menuItemExtent;
+
+  /// The height of each menu item. Default is 50.0.
+  final double menuItemExtent;
+
+  /// The width of the menu. If not specified, it will be 70% of the screen width.
   final double? menuWidth;
   final List<FocusedMenuItem> menuItems;
-  final bool? animateMenuItems;
+
+  /// Whether the menu items should animate in default to true.
+  final bool animateMenuItems;
+
+  /// The decoration to paint behind the menu items.
   final BoxDecoration? menuBoxDecoration;
+
+  /// The callback that is called when one of the menu items is pressed.
   final Function? onPressed;
-  final Duration? duration;
-  final double? blurSize;
-  final Color? blurBackgroundColor;
-  final double? bottomOffsetHeight;
-  final double? menuOffset;
+
+  /// The duration of the animation of the menu items. Default is 100ms.
+  final Duration duration;
+
+  /// The blur size of the background. Default is 4.0.
+  final double blurSize;
+
+  /// The color to use for the unfocused area.
+  final Color blurBackgroundColor;
+
+  /// The height of the bottom offset used as bottom safe area. Default is 0.
+  final double bottomOffsetHeight;
+
+  /// The height of the menu offset used as top safe area. Default is 0.
+  final double menuOffset;
 
   /// Actions to be shown in the toolbar.
   final List<Widget>? toolbarActions;
@@ -45,30 +65,55 @@ class FocusedMenuHolder extends StatefulWidget {
 
   /// Open with tap insted of long press.
   final bool openWithTap;
+
+  /// Controller to open and close the menu.
   final FocusedMenuHolderController? controller;
   final VoidCallback? onOpened;
   final VoidCallback? onClosed;
+
+  /// The duration of the animation of the menu items. Default is 400ms.
+  final Duration showItemsDuration;
+
+  /// The border radius of the menu items card. Default is 0.0.
+  final BorderRadius itemsCardBorderRadius;
+
+  /// The widget to be used as seperator between menu items.
+  final Widget? itemSeperatorWidget;
+
+  /// The padding of the menu items.
+  final EdgeInsets itemPadding;
+
+  /// Delta Duration for each item animation. Default is 200ms.
+  final int itemAnimationDuration;
 
   const FocusedMenuHolder({
     Key? key,
     required this.child,
     required this.menuItems,
     this.onPressed,
-    this.duration,
+    this.duration = const Duration(milliseconds: 100),
     this.menuBoxDecoration,
-    this.menuItemExtent,
-    this.animateMenuItems,
-    this.blurSize,
-    this.blurBackgroundColor,
+    this.menuItemExtent = 50.0,
+    this.animateMenuItems = true,
+    this.blurSize = 4.0,
+    this.blurBackgroundColor = const Color.fromRGBO(0, 0, 0, 0.7),
     this.menuWidth,
-    this.bottomOffsetHeight,
-    this.menuOffset,
+    this.bottomOffsetHeight = 0,
+    this.menuOffset = 0,
     this.toolbarActions,
     this.enableMenuScroll = true,
     this.openWithTap = false,
     this.controller,
     this.onOpened,
     this.onClosed,
+    this.showItemsDuration = const Duration(milliseconds: 400),
+    this.itemsCardBorderRadius = const BorderRadius.all(Radius.zero),
+    this.itemSeperatorWidget,
+    this.itemPadding = const EdgeInsets.symmetric(
+      vertical: 8.0,
+      horizontal: 14,
+    ),
+    this.itemAnimationDuration = 200,
   }) : super(key: key);
 
   @override
@@ -78,7 +123,7 @@ class FocusedMenuHolder extends StatefulWidget {
 class _FocusedMenuHolderState extends State<FocusedMenuHolder> {
   GlobalKey containerKey = GlobalKey();
   Offset childOffset = Offset(0, 0);
-  Size? childSize;
+  late Size childSize;
 
   _FocusedMenuHolderState(FocusedMenuHolderController? _controller) {
     if (_controller != null) {
@@ -122,7 +167,7 @@ class _FocusedMenuHolderState extends State<FocusedMenuHolder> {
     await Navigator.push(
       context,
       PageRouteBuilder(
-        transitionDuration: widget.duration ?? Duration(milliseconds: 100),
+        transitionDuration: widget.duration,
         pageBuilder: (context, animation, secondaryAnimation) {
           animation = Tween(begin: 0.0, end: 1.0).animate(animation);
           return FadeTransition(
@@ -137,11 +182,16 @@ class _FocusedMenuHolderState extends State<FocusedMenuHolder> {
               blurSize: widget.blurSize,
               menuWidth: widget.menuWidth,
               blurBackgroundColor: widget.blurBackgroundColor,
-              animateMenu: widget.animateMenuItems ?? true,
-              bottomOffsetHeight: widget.bottomOffsetHeight ?? 0,
-              menuOffset: widget.menuOffset ?? 0,
+              animateMenu: widget.animateMenuItems,
+              bottomOffsetHeight: widget.bottomOffsetHeight,
+              menuOffset: widget.menuOffset,
               toolbarActions: widget.toolbarActions,
               enableMenuScroll: widget.enableMenuScroll,
+              showItemsDuration: widget.showItemsDuration,
+              itemsCardBorderRadius: widget.itemsCardBorderRadius,
+              itemSeperatorWidget: widget.itemSeperatorWidget,
+              itemPadding: widget.itemPadding,
+              itemAnimationDuration: widget.itemAnimationDuration,
             ),
           );
         },

--- a/lib/src/widgets/focus_menu_holder.dart
+++ b/lib/src/widgets/focus_menu_holder.dart
@@ -106,14 +106,14 @@ class FocusedMenuHolder extends StatefulWidget {
     this.controller,
     this.onOpened,
     this.onClosed,
-    this.showItemsDuration = const Duration(milliseconds: 400),
+    this.showItemsDuration = const Duration(milliseconds: 100),
     this.itemsCardBorderRadius = const BorderRadius.all(Radius.zero),
     this.itemSeperatorWidget,
     this.itemPadding = const EdgeInsets.symmetric(
       vertical: 8.0,
       horizontal: 14,
     ),
-    this.itemAnimationDuration = 200,
+    this.itemAnimationDuration = 20,
   }) : super(key: key);
 
   @override

--- a/lib/src/widgets/focused_menu_datails.dart
+++ b/lib/src/widgets/focused_menu_datails.dart
@@ -8,13 +8,13 @@ class FocusedMenuDetails extends StatelessWidget {
   final List<FocusedMenuItem> menuItems;
   final BoxDecoration? menuBoxDecoration;
   final Offset childOffset;
-  final double? itemExtent;
-  final Size? childSize;
+  final double itemExtent;
+  final Size childSize;
   final Widget child;
   final bool animateMenu;
-  final double? blurSize;
+  final double blurSize;
   final double? menuWidth;
-  final Color? blurBackgroundColor;
+  final Color blurBackgroundColor;
   final double? bottomOffsetHeight;
   final double? menuOffset;
 
@@ -24,39 +24,61 @@ class FocusedMenuDetails extends StatelessWidget {
   /// Enable scroll in menu.
   final bool enableMenuScroll;
 
-  const FocusedMenuDetails(
-      {Key? key,
-      required this.menuItems,
-      required this.child,
-      required this.childOffset,
-      required this.childSize,
-      required this.menuBoxDecoration,
-      required this.itemExtent,
-      required this.animateMenu,
-      required this.blurSize,
-      required this.blurBackgroundColor,
-      required this.menuWidth,
-      required this.enableMenuScroll,
-      this.bottomOffsetHeight,
-      this.menuOffset,
-      this.toolbarActions})
-      : super(key: key);
+  /// The duration of the animation of the menu items. Default is 400ms.
+  final Duration showItemsDuration;
+
+  /// The border radius of the menu items card. Default is 0.0.
+  final BorderRadius itemsCardBorderRadius;
+
+  /// The widget to be used as seperator between menu items.
+  final Widget? itemSeperatorWidget;
+
+  final EdgeInsets itemPadding;
+
+  /// Delta Duration for each item animation. Default is 200ms.
+  final int itemAnimationDuration;
+
+  const FocusedMenuDetails({
+    Key? key,
+    required this.menuItems,
+    required this.child,
+    required this.childOffset,
+    required this.childSize,
+    required this.menuBoxDecoration,
+    this.itemExtent = 50.0,
+    required this.animateMenu,
+    required this.blurSize,
+    this.blurBackgroundColor = const Color.fromRGBO(0, 0, 0, 0.7),
+    required this.menuWidth,
+    required this.enableMenuScroll,
+    this.bottomOffsetHeight,
+    this.menuOffset,
+    this.toolbarActions,
+    this.showItemsDuration = const Duration(milliseconds: 400),
+    this.itemsCardBorderRadius = const BorderRadius.all(Radius.zero),
+    this.itemSeperatorWidget,
+    this.itemPadding = const EdgeInsets.symmetric(
+      vertical: 8.0,
+      horizontal: 14,
+    ),
+    this.itemAnimationDuration = 200,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     Size size = MediaQuery.of(context).size;
 
     final maxMenuHeight = size.height * 0.45;
-    final listHeight = menuItems.length * (itemExtent ?? 50.0);
+    final listHeight = menuItems.length * (itemExtent);
 
     final maxMenuWidth = menuWidth ?? (size.width * 0.70);
     final menuHeight = listHeight < maxMenuHeight ? listHeight : maxMenuHeight;
     final leftOffset = (childOffset.dx + maxMenuWidth) < size.width
         ? childOffset.dx
-        : (childOffset.dx - maxMenuWidth + childSize!.width);
-    final topOffset = (childOffset.dy + menuHeight + childSize!.height) <
+        : (childOffset.dx - maxMenuWidth + childSize.width);
+    final topOffset = (childOffset.dy + menuHeight + childSize.height) <
             size.height - bottomOffsetHeight!
-        ? childOffset.dy + childSize!.height + menuOffset!
+        ? childOffset.dy + childSize.height + menuOffset!
         : childOffset.dy - menuHeight - menuOffset!;
     return Scaffold(
       backgroundColor: Colors.transparent,
@@ -70,17 +92,18 @@ class FocusedMenuDetails extends StatelessWidget {
                 },
                 child: BackdropFilter(
                   filter: ImageFilter.blur(
-                      sigmaX: blurSize ?? 4, sigmaY: blurSize ?? 4),
+                    sigmaX: blurSize,
+                    sigmaY: blurSize,
+                  ),
                   child: Container(
-                    color:
-                        (blurBackgroundColor ?? Colors.black).withOpacity(0.7),
+                    color: blurBackgroundColor,
                   ),
                 )),
             Positioned(
               top: topOffset,
               left: leftOffset,
               child: TweenAnimationBuilder(
-                duration: Duration(milliseconds: 200),
+                duration: showItemsDuration,
                 builder: (BuildContext context, dynamic value, Widget? child) {
                   return Transform.scale(
                     scale: value,
@@ -104,8 +127,10 @@ class FocusedMenuDetails extends StatelessWidget {
                                 spreadRadius: 1)
                           ]),
                   child: ClipRRect(
-                    borderRadius: const BorderRadius.all(Radius.circular(5.0)),
-                    child: ListView.builder(
+                    borderRadius: itemsCardBorderRadius,
+                    child: ListView.separated(
+                      separatorBuilder: (context, index) =>
+                          itemSeperatorWidget ?? SizedBox.shrink(),
                       itemCount: menuItems.length,
                       padding: EdgeInsets.zero,
                       physics: enableMenuScroll
@@ -122,10 +147,9 @@ class FocusedMenuDetails extends StatelessWidget {
                                 alignment: Alignment.center,
                                 margin: const EdgeInsets.only(bottom: 1),
                                 color: item.backgroundColor ?? Colors.white,
-                                height: itemExtent ?? 50.0,
+                                height: itemExtent,
                                 child: Padding(
-                                  padding: const EdgeInsets.symmetric(
-                                      vertical: 8.0, horizontal: 14),
+                                  padding: itemPadding,
                                   child: Row(
                                     mainAxisAlignment:
                                         MainAxisAlignment.spaceBetween,
@@ -147,7 +171,8 @@ class FocusedMenuDetails extends StatelessWidget {
                                 );
                               },
                               tween: Tween(begin: 1.0, end: 0.0),
-                              duration: Duration(milliseconds: index * 200),
+                              duration: Duration(
+                                  milliseconds: index * itemAnimationDuration),
                               child: listItem);
                         } else {
                           return listItem;
@@ -166,8 +191,8 @@ class FocusedMenuDetails extends StatelessWidget {
                 child: AbsorbPointer(
                     absorbing: true,
                     child: Container(
-                        width: childSize!.width,
-                        height: childSize!.height,
+                        width: childSize.width,
+                        height: childSize.height,
                         child: child))),
           ],
         ),

--- a/lib/src/widgets/focused_menu_datails.dart
+++ b/lib/src/widgets/focused_menu_datails.dart
@@ -54,14 +54,14 @@ class FocusedMenuDetails extends StatelessWidget {
     this.bottomOffsetHeight,
     this.menuOffset,
     this.toolbarActions,
-    this.showItemsDuration = const Duration(milliseconds: 400),
+    this.showItemsDuration = const Duration(milliseconds: 20),
     this.itemsCardBorderRadius = const BorderRadius.all(Radius.zero),
     this.itemSeperatorWidget,
     this.itemPadding = const EdgeInsets.symmetric(
       vertical: 8.0,
       horizontal: 14,
     ),
-    this.itemAnimationDuration = 200,
+    this.itemAnimationDuration = 20,
   }) : super(key: key);
 
   @override


### PR DESCRIPTION
* Replace null checks on params with default values in the constructor.
* Add showItemsDuration param - duration of the menu appearing.
* Add itemsCardBorderRadius param - border radius of the menu.
* Add itemSeperator nullable widget with shrink default value - used ListView.seperator instead of builder and allow to give seperator from outside.
* Add itemPadding param - padding for each item in menu.
* Add itemAnimationDuration param - delta for bouncing animation for each item.